### PR TITLE
Auth

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,8 +13,11 @@
     </php>
 
     <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests</directory>
+        <testsuite name="auth">
+            <directory>tests/auth</directory>
+        </testsuite>
+        <testsuite name="message/send">
+            <directory>tests/message/send</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,8 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_CLASS" value="AppKernel" />
+        <env name="APP_ENV" value="test"/>
+        <env name="JWT_SECRET" value="example_secret_for_testing_only"/>
     </php>
 
     <testsuites>

--- a/src/AppBundle/Controller/MessageController.php
+++ b/src/AppBundle/Controller/MessageController.php
@@ -7,7 +7,7 @@ use FOS\RestBundle\Controller\FOSRestController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class MessageController extends FOSRestController
+class MessageController extends FOSRestController implements TokenAuthenticatedController
 {
     public function listAction()
     {

--- a/src/AppBundle/Controller/TokenAuthenticatedController.php
+++ b/src/AppBundle/Controller/TokenAuthenticatedController.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AppBundle\Controller;
+
+interface TokenAuthenticatedController
+{
+}

--- a/src/AppBundle/EventListener/ExceptionListener.php
+++ b/src/AppBundle/EventListener/ExceptionListener.php
@@ -5,6 +5,7 @@ namespace AppBundle\EventListener;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Class ExceptionListener.
@@ -21,6 +22,8 @@ class ExceptionListener
 
         if ($exception instanceof NotFoundHttpException) {
             $message = 'Not Found';
+        } elseif ($exception instanceof UnauthorizedHttpException) {
+            $message = 'Unauthorized';
         }
 
         $response->setContent(

--- a/src/AppBundle/EventSubscriber/TokenSubscriber.php
+++ b/src/AppBundle/EventSubscriber/TokenSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace AppBundle\EventSubscriber;
+
+use AppBundle\Controller\TokenAuthenticatedController;
+use Firebase\JWT\JWT;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+class TokenSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param FilterControllerEvent $event
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $controller = $event->getController();
+
+        /*
+         * $controller passed can be either a class or a Closure.
+         * This is not usual in Symfony but it may happen.
+         * If it is a class, it comes in array format
+         */
+        if (!is_array($controller)) {
+            return;
+        }
+
+        if ($controller[0] instanceof TokenAuthenticatedController) {
+            $authorization = $event->getRequest()->headers->get('Authorization');
+            $jwt = trim(preg_replace('/^(?:\s+)?Bearer\s/', '', $authorization));
+            try {
+                $decoded = JWT::decode($jwt, getenv('JWT_SECRET'), ['HS256']);
+            } catch (\Exception $e) {
+                throw new UnauthorizedHttpException('Unauthorized');
+            }
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::CONTROLLER => 'onKernelController',
+        );
+    }
+}

--- a/tests/message/send/HttpStatus401Test.php
+++ b/tests/message/send/HttpStatus401Test.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Message\Create;
+
+use Tests\TokenAuthenticatedWebTestCase;
+
+class HttpStatus401Test extends TokenAuthenticatedWebTestCase
+{
+    public static function setUpBeforeClass()
+    {
+        self::$accessToken = 'foo';
+    }
+
+    /**
+     * @dataProvider data
+     * @test
+     */
+    public function http_status_401($telephone, $content)
+    {
+        $message = [
+            'telephone' => $telephone,
+            'content' => $content,
+        ];
+
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/api/message/send',
+            [],
+            [],
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer '.self::$accessToken,
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode($message)
+        );
+
+        $this->assertEquals(401, $client->getResponse()->getStatusCode());
+    }
+
+    public function data()
+    {
+        $data = [];
+        $messages = json_decode(file_get_contents(__DIR__.'/data/http_status_200.json'))->httpBody;
+        foreach ($messages as $message) {
+            $data[] = [
+                $message->telephone,
+                $message->content,
+            ];
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
DDTD cycle implemented:

- `tests/message/send/HttpStatus401Test.php` fails
- `tests/message/send/HttpStatus401Test.php` passes

Now the API responds as described below if the right credentials are not provided:
```
{
  "status": 401,
  "message": "Unauthorized"
}
```